### PR TITLE
cesare-devel -> chain's clone function added

### DIFF
--- a/cdq
+++ b/cdq
@@ -1,0 +1,1049 @@
+[33mcommit 97335b891812a42e777867a698d1346cd8b20441[m[33m ([m[1;36mHEAD -> [m[1;32mcesare-devel[m[33m)[m
+Author: Cesare Tonola <c.tonola001@unibs.it>
+Date:   Fri Feb 3 13:58:19 2023 +0100
+
+    Chain -> clone() function added; it  calls propagateCloning(..) of Link and Joint to create an indipendent copy of the whole chain
+
+[33mcommit b7c628beff7a7bef5880e35adac5702b7badc69d[m[33m ([m[1;31morigin/master[m[33m, [m[1;31morigin/HEAD[m[33m, [m[1;32mmaster[m[33m)[m
+Author: Manuel Beschi <manuel.beschi@unibs.it>
+Date:   Wed Jan 11 09:45:42 2023 +0100
+
+    bugfix in spatial(Dual)Transformation
+
+[33mcommit 3d03b566b26407a2a05c6bebdfb88ecbfe938994[m
+Author: Manuel Beschi <manuel.beschi@unibs.it>
+Date:   Mon Dec 12 15:04:04 2022 +0100
+
+    manage malformed URDF without joint limits
+
+[33mcommit a7fca74fd4a60230eaff7b1249d461a751fbe437[m
+Author: Manuel Beschi <manuel.beschi@unibs.it>
+Date:   Mon Dec 12 15:02:20 2022 +0100
+
+    manage malformed URDF without joint limits
+
+[33mcommit a782a95311274c8b3f8f47ffacad6327e2b6e8ef[m
+Author: Manuel Beschi <manuel.beschi@unibs.it>
+Date:   Mon Dec 12 14:35:20 2022 +0100
+
+    bugfix in including primitivies
+
+[33mcommit 1877d43e2eb7d41e186c9ff121e72def9cfb76dd[m
+Author: Manuel Beschi <manuel.beschi@unibs.it>
+Date:   Mon Dec 12 12:40:59 2022 +0100
+
+    bugfix in including primitivies
+
+[33mcommit 80976de88cea03779d7e788368b9dcad7941ff54[m
+Author: Marco Faroni <marco.faroni@stiima.cnr.it>
+Date:   Thu Dec 8 18:12:19 2022 -0500
+
+    mfaroni : changed wrench sign in getWrench method (forces are now intended as applied TO the robot, not BY the robot)
+
+[33mcommit f592c3966cd85f1563c41716aa7f1f902fde00ba[m
+Author: Manuel Beschi <manuel.beschi@unibs.it>
+Date:   Thu Dec 8 10:57:01 2022 +0100
+
+    bugfix in getWrench when external wrenches are provided
+
+[33mcommit ebba94a4e4187ef97062c263491adf0341ce71c1[m
+Author: Manuel Beschi <manuel.beschi@unibs.it>
+Date:   Thu Nov 24 10:15:27 2022 +0100
+
+    clean rosdyn rosinstall
+
+[33mcommit d1e2988c21c36ef2ad3c0c2e0a4f3369aadc91dc[m
+Merge: 9cc0015 287f278
+Author: Manuel Beschi <manuel.beschi@unibs.it>
+Date:   Fri Nov 18 11:05:57 2022 +0100
+
+    Merge branch 'master' of https://github.com/CNR-STIIMA-IRAS/rosdyn
+
+[33mcommit 9cc001510957f73e6ba1b2f21af977240e589c4a[m
+Author: Manuel Beschi <manuel.beschi@unibs.it>
+Date:   Fri Nov 18 11:05:13 2022 +0100
+
+    moved rosdyn identification in a separed repository
+
+[33mcommit 287f278ba641f9c4e64ea7eb254233193df05c86[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Mon Jun 13 11:14:18 2022 +0200
+
+    clang reduce warnings
+
+[33mcommit d2de6f10491c64f5ed0ab9a97a1f27b00e15e332[m
+Merge: dee0aef d5770a9
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Wed Jun 1 17:45:01 2022 +0200
+
+    Merge pull request #15 from CNR-STIIMA-IRAS/nicola-devel
+    
+    URDF: check if q_max is greater than q_min
+
+[33mcommit d5770a96d25e64b59580e5501fc1fa37f5d7af21[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Tue Apr 5 10:39:10 2022 +0200
+
+    key
+
+[33mcommit ee0f956b62781d6aacd48a7d5ebc74a609a7e6ea[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Mon Apr 4 22:08:12 2022 +0200
+
+    test dep
+
+[33mcommit bb44678d0858575da1b50588d2acc9f0532f52cb[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Mon Apr 4 21:53:11 2022 +0200
+
+    test depend.
+
+[33mcommit 7a7f7707c092a47e1244ce2643dd0d907f4f994d[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Mon Apr 4 21:42:07 2022 +0200
+
+    test depend.
+
+[33mcommit 16c4f44cbbeb37d13d3a7c0666a4e320134eba2e[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Mon Apr 4 21:38:34 2022 +0200
+
+    test depend.
+
+[33mcommit edf0c4d2af28c322498ead7895e2bb7996e2aca6[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Mon Apr 4 21:35:12 2022 +0200
+
+    test depend.
+
+[33mcommit 1ecfa58f41a77308a616e5d4c6e76bf987f17dfc[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Mon Apr 4 21:32:05 2022 +0200
+
+    test depend.
+
+[33mcommit 64512c5f621d98ed7fc4729b773790b7f017f5f1[m
+Merge: cd468a2 6b4b2a3
+Author: Marco Faroni <marco.faroni@stiima.cnr.it>
+Date:   Wed Mar 30 17:48:33 2022 +0200
+
+    Merge branch 'nicola-devel' of https://github.com/CNR-STIIMA-IRAS/rosdyn into nicola-devel
+
+[33mcommit cd468a20408aa948eea85e8bb9e9ff4b141a7265[m
+Author: Marco Faroni <marco.faroni@stiima.cnr.it>
+Date:   Wed Mar 30 17:48:30 2022 +0200
+
+    marco: added function copy chain to chainPtr
+
+[33mcommit 6b4b2a30843ab9122da6414e9854efedfface46b[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Wed Mar 23 14:01:25 2022 +0100
+
+    error from clang..
+
+[33mcommit b680591f6cc0cf3299d113fa9a86e2f0680b03f2[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Wed Mar 9 23:36:11 2022 +0100
+
+    cleanup of mess
+
+[33mcommit 1083fce6e6acc4a147081339a65aea0ae71ebf79[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Wed Mar 9 23:03:17 2022 +0100
+
+    URDF: check if q_max is greater than q_min
+
+[33mcommit dee0aef3722788b90050da22d3ae79ec996e0172[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Mon Mar 7 16:44:37 2022 +0100
+
+    nicola: bugfix CMakeLists.txt
+
+[33mcommit ec7e849a038424694b9d5cef81ec60c87e01b0ba[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Mon Mar 7 16:34:34 2022 +0100
+
+    nicola: bugfix in CMakeLists.txt
+
+[33mcommit 48d2b8eaa0425b2290fb53a0588ae7cdb89ab6ec[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Mon Mar 7 11:51:28 2022 +0100
+
+    nicola: removed old dependency on eigen_state_systems
+
+[33mcommit 46bffb6ad380672285fdb5083b638ab595e7e304[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Fri Mar 4 17:02:39 2022 +0100
+
+    kin saturation
+
+[33mcommit 00d96b3b8a339e73a75a5972a6881cec80ae14d5[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Sat Feb 12 08:56:00 2022 +0100
+
+    rosdyn_identification: append_trajectories is in name_sorting
+
+[33mcommit b2e26620faa231b12f5c14ddd1cf4c8cbc249e3f[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Thu Jan 27 22:54:08 2022 +0100
+
+    nicola: colcon compatibility
+
+[33mcommit a11156f08a0e51ff664108480ce074b36e87873c[m
+Merge: 1e6a432 2ccb834
+Author: Manuel Beschi <ManuelBeschi@users.noreply.github.com>
+Date:   Wed Jun 9 07:55:18 2021 +0200
+
+    Merge pull request #11 from CNR-STIIMA-IRAS/copy-chain-constructor
+    
+    Copy chain constructor
+
+[33mcommit 2ccb834cae4fe7ca36250c0f3957a1616018c415[m
+Author: nicola pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Mon Jun 7 18:06:20 2021 +0200
+
+    fix compatibility with new ur_description (tests)
+
+[33mcommit 91f9d2e054c9fc8286f5673b0a047aa8a6f1a3d4[m
+Author: nicola pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Tue May 25 13:08:05 2021 +0200
+
+    copy ctor, and operator=
+
+[33mcommit 840e2b8eda94a4d065e403971f2f32e254e14e90[m
+Author: nicola pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Tue May 25 12:23:56 2021 +0200
+
+    copy ctor, and operator=
+
+[33mcommit 5b1610408733e9beec2f350eb45ff0f739b1e875[m
+Author: nicola pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Tue May 25 11:17:39 2021 +0200
+
+    definitions moved in a implementation file
+
+[33mcommit 1e6a43225938ed9a05f0d3a866667e5640fff6a1[m
+Author: Manuel Beschi <ManuelBeschi@users.noreply.github.com>
+Date:   Thu Apr 29 09:13:00 2021 +0200
+
+    Update README.md
+
+[33mcommit 9082fb7f45c99f3458381bd4192f18680317fb76[m
+Merge: 9002e4d 7676477
+Author: Manuel Beschi <ManuelBeschi@users.noreply.github.com>
+Date:   Thu Apr 22 21:52:59 2021 +0200
+
+    Merge pull request #10 from CNR-STIIMA-IRAS/nicola-devel
+    
+    Nicola devel
+
+[33mcommit 767647766aefe0a8f4c156cbf6058bd84d7c99f4[m
+Author: nicola pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Thu Apr 22 10:02:24 2021 +0200
+
+    removed static clause
+
+[33mcommit 7bf2e28db905c95a79e586ba88c0e24e96d7cfb8[m
+Author: nicola pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Tue Apr 20 17:25:52 2021 +0200
+
+    geometric consistency check
+
+[33mcommit 7afb827164ecfd0a86df1d79396de809297e69c7[m
+Author: nicola pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Tue Apr 20 17:17:41 2021 +0200
+
+    geometric consistency check
+
+[33mcommit 9002e4d23ecba95baa16ba05106e055e160aeba7[m
+Author: nicola pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Thu Apr 1 18:08:52 2021 +0200
+
+    wip
+
+[33mcommit cf5f567a6d6ea6603e18bc7c3ffdc118c86df43e[m
+Author: nicola pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Mon Mar 15 19:08:56 2021 +0100
+
+    bugfix in m_DDa_max (error in merging)
+
+[33mcommit bb0e15ee5fb7b3ae20c2ddc1e2f3790603eb3fc5[m
+Author: nicola pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Mon Mar 15 13:54:06 2021 +0100
+
+    rosdyn_utilities moved to a separate repository
+
+[33mcommit a66175565ed0d3de737b9e1574b23eb71f892e9c[m
+Merge: eb2083a 1fda9c9
+Author: Manuel Beschi <ManuelBeschi@users.noreply.github.com>
+Date:   Mon Mar 15 09:52:39 2021 +0100
+
+    Merge pull request #9 from CNR-STIIMA-IRAS/chain-state
+    
+    Chain state & some fixes & acceleration limits
+
+[33mcommit 1fda9c93870437f46b5f0358b5ba568972b1a175[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Thu Mar 11 10:39:23 2021 +0100
+
+    fix default acc
+
+[33mcommit 6dc4e3d4f1e8f4c0333681710c33fdc6d016b2fe[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Wed Mar 10 22:22:25 2021 +0100
+
+    prepare PR
+
+[33mcommit 843f4e2cea51d201bb8d9cf54b7caeffb5768243[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Wed Mar 10 22:08:28 2021 +0100
+
+    prepare PR
+
+[33mcommit d6d0831cb909522f2270cf3ff691de888cf87d68[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Wed Mar 10 22:05:30 2021 +0100
+
+    prepare PR
+
+[33mcommit 4156567453300d34617a101d52c9d7b72ad402bc[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Wed Mar 10 21:57:37 2021 +0100
+
+    prepare PR
+
+[33mcommit 4d4645b152ef411c057c65395115971ebf904225[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Wed Mar 10 21:53:29 2021 +0100
+
+    prepare PR
+
+[33mcommit 39c514569854114ed5403cc6fa234e1740e3be77[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Wed Mar 10 21:51:39 2021 +0100
+
+    prepare PR
+
+[33mcommit 08e56394d6c615149e8d38711162c46613f1b00d[m
+Author: nicola pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Wed Mar 10 18:11:33 2021 +0100
+
+    added the possibility to override the limits (getting the values from the moveit! joint_limits.yaml)
+
+[33mcommit 4b84a606d44d504fad1bbe6f3d2b1794c6fc92ac[m
+Author: nicola pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Wed Mar 10 18:06:18 2021 +0100
+
+    added DDqmax, init. Split primites.h in two files. Added tests
+
+[33mcommit cf53c48f225bb8bba077859e25487be3750895c6[m
+Author: nicola pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Wed Mar 10 17:24:50 2021 +0100
+
+    cleaning for PR
+
+[33mcommit eb2083a1af69e54a74d353d0cfcec5f629cc38ec[m
+Author: Manuel Beschi <manuel.beschi@unibs.it>
+Date:   Thu Feb 4 09:21:12 2021 +0100
+
+    add computation of multiturn solution
+
+[33mcommit ee0d4f00617c1431f088a49ee1554b5593792ccf[m
+Author: Manuel Beschi <manuel.beschi@unibs.it>
+Date:   Thu Dec 17 14:11:49 2020 +0100
+
+    change std::__cxx11::string to std::string
+
+[33mcommit ed6c9b0a3ec44ea8fe3786d4ed744d20b6fe1778[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Wed Nov 18 14:15:20 2020 +0100
+
+    bug fix
+
+[33mcommit 8cf599a76ae1b374df464202c758e4b7fad7dfd4[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Fri Nov 13 17:57:49 2020 +0100
+
+    add link-wise methods
+
+[33mcommit f88268f617a25a0de20335ef7a886351130837cb[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Fri Oct 30 17:02:46 2020 +0100
+
+    fix travis
+
+[33mcommit 59f1e2ebe4c367236e59269a0a589fd10f92bb11[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Fri Oct 30 16:49:42 2020 +0100
+
+    modify rosinstall
+
+[33mcommit 03dcd9f1f2706083db09ad4fa84c38d5d75f6c92[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Fri Sep 11 12:16:08 2020 +0200
+
+    bug fix
+
+[33mcommit 099ad468e6ebdd050bb2cfc32b48f5eaf097dd7a[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Fri Sep 11 12:07:32 2020 +0200
+
+    bug fix
+
+[33mcommit 449201e96e3d95474ef8555cf9d2e6631e062964[m
+Merge: f7a701e 6871d12
+Author: Manuel Beschi <ManuelBeschi@users.noreply.github.com>
+Date:   Fri Sep 11 11:53:01 2020 +0200
+
+    Merge pull request #7 from CNR-STIIMA-IRAS/np-boost
+    
+    clean code linting of the shared pointers
+
+[33mcommit f7a701e96e50695f222a36cb24ec206da2af44a6[m
+Merge: a5a7f25 46b03b7
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Fri Sep 11 11:47:00 2020 +0200
+
+    Merge branch 'master' of https://github.com/CNR-STIIMA-IRAS/rosdyn
+
+[33mcommit a5a7f25ba6e8fc7e1ac101c8b75d1bae6143435b[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Fri Sep 11 11:46:49 2020 +0200
+
+    add spatialIntegration
+
+[33mcommit 6871d1248488bc31d7c8391a63574de58d07809c[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Wed Jul 29 11:16:38 2020 +0200
+
+    nicola: shared ptr definitions
+
+[33mcommit 937f181e363fced077acd3439d461b562de27e3d[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Wed Jul 29 08:33:12 2020 +0200
+
+    boost::shared_ptr replaced by std:: whenever possible
+
+[33mcommit fda2bad23534e227200c5fba4e4a75480b3accf7[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Wed Jul 29 08:32:04 2020 +0200
+
+    boost::shared_ptr replaced by std:: whenever possible
+
+[33mcommit 46b03b73b533252bb16d091dcbec1a295101eb65[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Tue Jul 7 17:36:51 2020 +0200
+
+    nicola: travis
+
+[33mcommit d9375db9f34f2b4a36f7a76fa2da8838de0477f9[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Fri Jul 3 13:02:01 2020 +0200
+
+    check roslint
+
+[33mcommit 11ca6d3eaec822b08b39b70d299be20aee8008e8[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Wed Jul 1 16:33:15 2020 +0200
+
+    nicola: bug in .travis
+
+[33mcommit 4bdd9546c905556e46d65ae549b99f584acc37fb[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Wed Jul 1 16:20:58 2020 +0200
+
+    nicola: bug in .travis
+
+[33mcommit 6ea4ddb4aa304a45538085f4d369a8eb2697a82d[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Wed Jul 1 15:40:43 2020 +0200
+
+    nicola: bug in .travis
+
+[33mcommit cabe55cfdb8d258976db81eb38fb5d1e66d62196[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Wed Jul 1 15:39:09 2020 +0200
+
+    nicola: bug in .travis
+
+[33mcommit 7fa9eda3fd53f7bc206ebf82ac88395c548beefd[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Wed Jul 1 10:10:19 2020 +0200
+
+    nicola: bug in .travis
+
+[33mcommit c478515facf35a52e3f5e5092a02c44e8060b7de[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Wed Jul 1 10:06:04 2020 +0200
+
+    nicola: bug in .travis
+
+[33mcommit c097639d9232aad15e702d18e51fc59e7f3d3a2b[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Wed Jul 1 10:04:37 2020 +0200
+
+    nicola: bug in .travis
+
+[33mcommit 3ef82e839215edeecb16ae17a4a6d16b3897ce8c[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Wed Jul 1 10:01:50 2020 +0200
+
+    nicola: bug in .travis
+
+[33mcommit 1781ff3bc999a1f53b3ff1d44fd91e898e4fa5ac[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Wed Jul 1 09:59:38 2020 +0200
+
+    nicola: bug in .travis
+
+[33mcommit ea8930cfb23c2bf869d1ac86ef76f585d9a6e240[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Wed Jul 1 09:55:18 2020 +0200
+
+    nicola: bug in .travis
+
+[33mcommit d5388524acf0504f3b27348da05b153bc66faa45[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Wed Jul 1 09:47:25 2020 +0200
+
+    nicola: bug in .travis
+
+[33mcommit 623cf4f48abbfb2f416387c9539c8526f8c1e723[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Wed Jul 1 09:46:30 2020 +0200
+
+    nicola: bug in .travis
+
+[33mcommit 403974b3aba044e78d71d41901178ade8cda190c[m
+Author: Nicola Pedrocchi <nicola.pedrocchi@stiima.cnr.it>
+Date:   Wed Jul 1 09:35:15 2020 +0200
+
+    nicola: bug in .travis
+
+[33mcommit 47c089f31ef02c30f8879db5cc2638d1d4aaa9ae[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Wed May 13 08:47:06 2020 +0200
+
+    print estimation results on terminal
+
+[33mcommit 3f0856cb627e59023806bb0e82cc03df61b012eb[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Wed May 13 08:43:37 2020 +0200
+
+    remove ResultsDialog due to a bug
+
+[33mcommit 6608051e9283bc37085acb71d141c547e81b631b[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Thu May 7 11:47:06 2020 +0200
+
+     add results_popup
+
+[33mcommit d2069d278b175d629d9ed35019b73194fd7cfa84[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Wed May 6 11:37:47 2020 +0200
+
+    bugfix in ik
+
+[33mcommit 48e1c02f2df00e09c27cc0683b1c49a6cc019038[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Thu Apr 30 11:12:45 2020 +0200
+
+    fix error in local ik
+
+[33mcommit 7b7f2ac86e43fbeecd95ebea3c64698a6b4844e8[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Thu Apr 30 11:10:05 2020 +0200
+
+    add weighted ik
+
+[33mcommit 6275b116b5c64e6363788ed348a505459e532d26[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Thu Apr 30 10:47:22 2020 +0200
+
+    extend ik for robots with more than 6 joints
+
+[33mcommit 9da4b94fdde4780c1f4d35288b5faf5a92f77429[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Thu Apr 30 10:33:11 2020 +0200
+
+    update gui
+
+[33mcommit 81dc55f5ead210e77bd3ff5c1daebcdaceb9c241[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Wed Apr 3 08:13:43 2019 +0200
+
+    add check to chain well definition
+
+[33mcommit b826dc479df9d3ce3b5fe79643aaa40e9582d5f8[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Thu Mar 28 16:53:38 2019 +0100
+
+    Added local ik QP solver
+
+[33mcommit 3dc5dbb8e25ae5603fbd04f0ac110c0d712b2b36[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Thu Mar 28 16:08:34 2019 +0100
+
+    Added local ik QP solver
+
+[33mcommit 396cd8b3759f016e1c4787f54dad26c755020886[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Fri Mar 22 18:02:38 2019 +0100
+
+    update rosdyn.rosinstall
+
+[33mcommit 8b7c30128769071242dfe7cec971e6607454b6f9[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Fri Mar 22 18:00:51 2019 +0100
+
+    update rosdyn.install
+
+[33mcommit 9425e910cc455b2d0618209c910dc5a3cde207c1[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Fri Mar 22 17:53:43 2019 +0100
+
+    update REAME
+
+[33mcommit 4d0dd5c8a44fc4d692cf64fa3ed908237677bef6[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Fri Mar 22 17:45:05 2019 +0100
+
+    README improved
+
+[33mcommit 0c339fff695d39479fbbfbc805e2e30805ab08d8[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Fri Mar 22 16:50:33 2019 +0100
+
+    add EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+[33mcommit fdef4c9d864a199fdb9326a471f56e916213c04c[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Fri Mar 22 16:47:55 2019 +0100
+
+    remove DEBUG messages
+
+[33mcommit 2b73eeb8f2b8df27ab608dc3540a5102639f07f9[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Wed Mar 20 11:04:46 2019 +0100
+
+    add getTransformations
+
+[33mcommit 9107d018a944cda05d18f669e890842465245fcf[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Thu Mar 14 16:52:26 2019 +0100
+
+    add spatial algebra readme
+
+[33mcommit fbba95aee8111594a2507cda7d0ad37c34d75f67[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Wed Mar 13 08:21:30 2019 +0100
+
+    update docuemntation
+
+[33mcommit 270ecc14a741800019a0a34b9b2918c6ffb0bd2a[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Wed Mar 13 08:19:48 2019 +0100
+
+    update docuemntation
+
+[33mcommit 9aa0578c4b387c61028e5e623eaba64831974b6c[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Wed Mar 13 08:18:45 2019 +0100
+
+    update docuemntation
+
+[33mcommit 4f6013ba12763c2ccb12603716606c62b3714bdb[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Wed Mar 13 08:17:20 2019 +0100
+
+    update documentation of rosdyn_core package
+
+[33mcommit a1a44a04fd61737e0f0cdd2e804b236c528f6bb8[m
+Merge: 686bed6 91ebe41
+Author: Marco Faroni <marco@stiima.cnr.it>
+Date:   Wed Feb 27 13:40:18 2019 +0100
+
+    Merge branch 'master' of https://github.com/CNR-STIIMA-IRAS/rosdyn
+
+[33mcommit 686bed65d43d3a3fcc44d75efa8bc907ed639ec4[m
+Author: Marco Faroni <marco@stiima.cnr.it>
+Date:   Wed Feb 27 13:37:10 2019 +0100
+
+    Add get functions for twists and twist derivatives.
+
+[33mcommit 91ebe414096b1fe4c8561832407dfbf2d0ac557b[m
+Merge: 21dbbf8 4150b06
+Author: Leonhard Euler <leonhard.euler@stiima.cnr.it>
+Date:   Tue Feb 5 15:23:46 2019 +0100
+
+    fix conflicts
+
+[33mcommit 21dbbf8f0e29f9faca3ade63b031d513cf09de6b[m
+Author: Leonhard Euler <leonhard.euler@stiima.cnr.it>
+Date:   Tue Feb 5 15:22:47 2019 +0100
+
+    change on primitives
+
+[33mcommit 4150b068146d7d8181d1afdec440f36d97daac72[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Mon Feb 4 15:39:54 2019 +0100
+
+    add comment
+
+[33mcommit bcf6d3f8fc4e1b4760b14662f90019b794c8d0a7[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Wed Jan 23 11:14:35 2019 +0100
+
+    fix frame distance orientation error sign
+
+[33mcommit 6647f53b64eb1f83c46bdd67763dbffff7292554[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Mon Jan 21 17:13:47 2019 +0100
+
+    add frame distance
+
+[33mcommit 0044145e3ac2eb75820453dcae38413525175808[m
+Author: ManuelBeschi <manuel.beschi@gmail.com>
+Date:   Wed Jan 16 18:27:49 2019 +0100
+
+    add frame distance computation
+
+[33mcommit ffdc81df2c7d5198aa82964beb7bea730f3a3764[m
+Author: Manuel Beschi <manuel.beschi@itia.cnr.it>
+Date:   Mon Jan 14 10:49:32 2019 +0100
+
+    change readme
+
+[33mcommit 61827dcdf5ff8f5211eebea77a691f0c5ed842e2[m
+Merge: 65bc49e 0d20d13
+Author: Leonhard Euler <leonhard.euler@stiima.cnr.it>
+Date:   Mon Jan 14 09:58:57 2019 +0100
+
+    manuel
+
+[33mcommit 65bc49e6fd639b733e779d5c7ca2e6b68bed4148[m
+Author: Leonhard Euler <leonhard.euler@stiima.cnr.it>
+Date:   Mon Jan 14 09:58:22 2019 +0100
+
+    manuel
+
+[33mcommit 0d20d138373aef4a4d35bbd051f8923c5b5bac51[m
+Author: Manuel Beschi <manuel.beschi@itia.cnr.it>
+Date:   Fri Jan 11 13:05:51 2019 +0100
+
+    fix inline missing
+
+[33mcommit 5b68f584d31343636b1796edcdcb95cdd233c067[m
+Author: Manuel Beschi <manuel.beschi@itia.cnr.it>
+Date:   Tue Jan 8 15:49:47 2019 +0100
+
+    update README.md
+
+[33mcommit fbd0aca46ac66fc898b8046669fca2a6e1c163d5[m
+Author: Manuel Beschi <manuel.beschi@itia.cnr.it>
+Date:   Tue Jan 8 15:48:56 2019 +0100
+
+    update README.md
+
+[33mcommit b149e6f48e8497c930c9dccf947e4e660f3609d3[m
+Author: Manuel Beschi <manuel.beschi@itia.cnr.it>
+Date:   Tue Jan 8 14:31:48 2019 +0100
+
+    update README.md
+
+[33mcommit bc04767fd5c5165ddac12750bad429f9629ebffc[m
+Author: Manuel Beschi <manuel.beschi@itia.cnr.it>
+Date:   Tue Jan 8 14:06:41 2019 +0100
+
+    updated documentation
+
+[33mcommit 4ab07794d98ade4e8d51f6a19933251c1354bc06[m
+Author: Manuel Beschi <manuel.beschi@itia.cnr.it>
+Date:   Fri Dec 21 13:40:18 2018 +0100
+
+    fix filtering bug
+
+[33mcommit d18557609f387b80a9b63bd3eb45b14a11629760[m
+Merge: 8f16148 d0986b4
+Author: Manuel Beschi <manuel.beschi@itia.cnr.it>
+Date:   Wed Dec 19 09:45:09 2018 +0100
+
+    merge melodic-devel with master
+
+[33mcommit 8f161488a363bf73494e5d7b1f684dbbea267774[m
+Author: Manuel Beschi <manuel.beschi@itia.cnr.it>
+Date:   Wed Dec 19 08:53:23 2018 +0100
+
+    add example
+
+[33mcommit d0986b4ff3af95efe34c7b1c28308d0450a29fa5[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Tue Dec 18 11:40:48 2018 +0100
+
+    nicola: add dependency to Eigen3 in CMakeLists (catkin_package macro) to sole the broken dep in joint_cart_telep
+
+[33mcommit 27498e2631dc94cee9b23e1f15d0718fd7dd6c8c[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Tue Dec 18 11:38:48 2018 +0100
+
+    nicola: add dependency to Eigen3 in CMakeLists (catkin_package macro) to sole the broken dep in joint_cart_telep
+
+[33mcommit 42faca6e876ef338d065e4f9d00d1c02b284b400[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Tue Dec 4 09:28:00 2018 +0100
+
+    README fixed
+
+[33mcommit 2e1d4cf9ee7ba3e99b2033d742d9d3e4a6a236f8[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Tue Dec 4 09:27:14 2018 +0100
+
+    README fixed
+
+[33mcommit 18ccb5760808e2801f269b6c3b01ec8ecbcd2ba8[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Mon Dec 3 22:59:17 2018 +0100
+
+    nicola: install header
+
+[33mcommit 447f7967333ae2131c2deffdcffb0f3b72744ad6[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Mon Dec 3 22:56:14 2018 +0100
+
+    nicola: install header
+
+[33mcommit a3ed8bc92c4a0a4deec07a7a487139682482f2f4[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Mon Dec 3 22:46:27 2018 +0100
+
+    nicola: install header
+
+[33mcommit 2fc9fdad11ae09b11d6489c37d975d76dc614afd[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Mon Dec 3 22:45:43 2018 +0100
+
+    nicola: install header
+
+[33mcommit af66579a134ec87e57ad3ab45d7a6d7f0f338172[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Mon Dec 3 22:44:28 2018 +0100
+
+    nicola: install header
+
+[33mcommit 3e89398f03366685110aa508e2ac9c873dd2a243[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Mon Dec 3 22:38:55 2018 +0100
+
+    nicola: install header
+
+[33mcommit 382d1ed00370b21d8b7fb656c1ca15a01dfacdde[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Mon Dec 3 21:36:27 2018 +0100
+
+    nicola: install header
+
+[33mcommit 31cfc762a51f7c1416d3b0173d307e1bb1d37b5f[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Mon Dec 3 21:35:48 2018 +0100
+
+    nicola: install header
+
+[33mcommit 291676965980a073681500f997ffc00c3855e1f6[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Mon Dec 3 21:18:35 2018 +0100
+
+    nicola: install header
+
+[33mcommit 0ab03bd152e3a96d856949768ae8a4a9d2c0b127[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Mon Dec 3 21:05:34 2018 +0100
+
+    nicola: install header
+
+[33mcommit 383d251362d9f6fb9a329c33f7e4d7f629d864c5[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Mon Dec 3 20:50:41 2018 +0100
+
+    nicola: install header
+
+[33mcommit 4abc059e76cd796340327890a7caf0c1dee461b6[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Mon Dec 3 20:39:54 2018 +0100
+
+    nicola: install header
+
+[33mcommit 860c6b0c7586fa215502e649f790d5b1ca44c84d[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Mon Dec 3 19:19:26 2018 +0100
+
+    nicola: non capisco
+
+[33mcommit 82810494a6ca8499f462889be20e7607047e4c8d[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Mon Dec 3 18:54:47 2018 +0100
+
+    nicola: readme.md
+
+[33mcommit b3a63f55d791c1196d0e3ea6ef0713bf1a28c353[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Mon Dec 3 18:53:46 2018 +0100
+
+    nicola: readme.md
+
+[33mcommit 66a3f05d1f44d401fd20e8a566d4c689d8c02828[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Mon Dec 3 18:44:48 2018 +0100
+
+    nicola: added travis ci
+
+[33mcommit 1cbe7ef34a01e5bdf93d06675a7f4f0d43d86a1b[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Mon Dec 3 18:33:34 2018 +0100
+
+    nicola: added travis ci
+
+[33mcommit 9f44d2cb0cad24e4792a0c03cf776fcf5ce6d91c[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Mon Dec 3 18:31:23 2018 +0100
+
+    nicola: added travis ci
+
+[33mcommit 0453db9b7fa2b0c730281ae72a68e7d0adbc25dc[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Mon Dec 3 18:23:06 2018 +0100
+
+    nicola: added travis ci
+
+[33mcommit 20a1b32ed5fc9bdf746e24eefb173e0be39b59d2[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Mon Dec 3 18:22:19 2018 +0100
+
+    nicola: added travis ci
+
+[33mcommit c48060f446a3e14d317e965aeb1d1b73f3a65114[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Mon Dec 3 18:20:43 2018 +0100
+
+    nicola: added travis ci
+
+[33mcommit b59d3278f3cc1e4dcf12d8ed4a5a027e78afb9a4[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Mon Dec 3 18:19:39 2018 +0100
+
+    nicola: added travis ci
+
+[33mcommit d0efdc6b1cef2a641328c9e8b81e348ac4decc2a[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Mon Dec 3 18:18:39 2018 +0100
+
+    nicola: added travis ci
+
+[33mcommit 5f8812f81799ae5860b88e7378450516b2ec9e45[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Mon Dec 3 18:17:42 2018 +0100
+
+    nicola: added travis ci
+
+[33mcommit ea8e98b7eed6c7390f43f5bb04b4fa73c4213810[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Mon Dec 3 18:14:07 2018 +0100
+
+    nicola: added travis ci
+
+[33mcommit befbc5bd0973145ebbc10272423cc633930866e8[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Mon Dec 3 18:13:00 2018 +0100
+
+    nicola: added travis ci
+
+[33mcommit 50744d41e175c3671f365d00f5aa4d47f8700648[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Mon Dec 3 18:03:36 2018 +0100
+
+    nicola: added travis ci
+
+[33mcommit 29c369bd623f534cefcdfd51adccb1249fc9d570[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Mon Dec 3 18:00:33 2018 +0100
+
+    nicola: added travis ci
+
+[33mcommit a62e7620cf187cbcd5e62bd6d27cfe0601afe89e[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Mon Dec 3 17:59:06 2018 +0100
+
+    nicola: added travis ci
+
+[33mcommit 1b0e297e50e75e5b08808ae75464327d28990a3b[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Mon Dec 3 17:56:08 2018 +0100
+
+    nicola: added travis ci
+
+[33mcommit b93d719d64e6e2174f7d356e7397e5a2e414deca[m
+Merge: 1925599 a81db1c
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Mon Dec 3 17:47:11 2018 +0100
+
+    Merge branch 'master' of https://github.com/CNR-STIIMA-IRAS/rosdyn into melodic-devel
+
+[33mcommit a81db1c465629961397e3becfc1a005e3066ba3e[m
+Author: Manuel Beschi <manuel.beschi@itia.cnr.it>
+Date:   Mon Dec 3 12:24:27 2018 +0100
+
+    update readme
+
+[33mcommit 37501120f21feb8f3da263f20868577bbeebecfa[m
+Author: Manuel Beschi <manuel.beschi@itia.cnr.it>
+Date:   Mon Dec 3 12:22:57 2018 +0100
+
+    update readme
+
+[33mcommit 649674dc96b38197de9d7132357c7a8179e94c5f[m
+Author: Manuel Beschi <manuel.beschi@itia.cnr.it>
+Date:   Mon Dec 3 11:31:53 2018 +0100
+
+    add rosinstall file
+
+[33mcommit 1925599702f1e744f05bc430e109c695e8eded72[m
+Author: nicola pedrocchi <nicola.pedrocchi@itia.cnr.it>
+Date:   Fri Nov 30 19:40:47 2018 +0100
+
+    nicola: melodic and kinetic back-compatibility (see #if ROS_VERSION in prtimitives.h)
+
+[33mcommit ae3eb9318a6f7a517a1eff9f4136f122259b1cde[m
+Author: ManuelBeschi <ManuelBeschi@users.noreply.github.com>
+Date:   Thu Nov 29 13:13:02 2018 +0100
+
+    Update README.md
+
+[33mcommit cf0ba86d2c9b10cbe02222ecc036656a3a234424[m
+Author: Manuel Beschi <manuel.beschi@itia.cnr.it>
+Date:   Thu Nov 29 13:12:20 2018 +0100
+
+    moving examples to rosdyn_examples
+
+[33mcommit 4a9e0701cb08d105b76602704619aee0c938e369[m
+Author: Manuel Beschi <manuel.beschi@itia.cnr.it>
+Date:   Thu Nov 29 12:06:49 2018 +0100
+
+    add readme
+
+[33mcommit 62e87e444cef4d8c7092625c876044375adbe897[m
+Merge: 6769cd4 e1db2b3
+Author: Manuel Beschi <manuel.beschi@itia.cnr.it>
+Date:   Thu Nov 29 11:59:06 2018 +0100
+
+    Merge branch 'master' of https://github.com/CNR-STIIMA-IRAS/rosdyn
+
+[33mcommit 6769cd49cc78c3aa3812e0a147a76c4df4f49a66[m
+Author: Manuel Beschi <manuel.beschi@itia.cnr.it>
+Date:   Thu Nov 29 11:58:55 2018 +0100
+
+    first commit of rosdyn!
+
+[33mcommit e1db2b38a6c7087f964e9e9d13b8edce526b8755[m
+Author: ManuelBeschi <ManuelBeschi@users.noreply.github.com>
+Date:   Thu Nov 29 11:57:45 2018 +0100
+
+    Initial commit

--- a/rosdyn_core/include/rosdyn_core/internal/primitives_impl.h
+++ b/rosdyn_core/include/rosdyn_core/internal/primitives_impl.h
@@ -232,6 +232,46 @@ inline const Eigen::Vector6d& Joint::getScrew_of_child_in_parent()
   return m_screw_of_c_in_p;
 }
 
+inline rosdyn::JointPtr& Joint::propagateCloning(const rosdyn::LinkPtr& cloned_parent_link)
+{
+  rosdyn::JointPtr cloned_joint = std::make_shared<rosdyn::Joint>();
+
+  cloned_joint->m_type = this->m_type;
+
+  cloned_joint->m_q_max = this->m_q_max;
+  cloned_joint->m_q_min = this->m_q_min;
+  cloned_joint->m_Dq_max = this->m_Dq_max;
+  cloned_joint->m_DDq_max= this->m_DDq_max;
+  cloned_joint->m_tau_max= this->m_tau_max;
+
+  cloned_joint->m_T_pj= this->m_T_pj;
+  cloned_joint->m_last_T_pc= this->m_last_T_pc;
+  cloned_joint->m_last_R_jc= this->m_last_R_jc;
+
+  cloned_joint->m_screw_of_c_in_p= this->m_screw_of_c_in_p;
+
+  cloned_joint->m_axis_in_j= this->m_axis_in_j;
+  cloned_joint->m_skew_axis_in_j= this->m_skew_axis_in_j;
+  cloned_joint->m_square_skew_axis_in_j= this->m_square_skew_axis_in_j;
+  cloned_joint->m_identity= this->m_identity;
+
+  cloned_joint->m_axis_in_p= this->m_axis_in_p;
+  cloned_joint->m_skew_axis_in_p= this->m_skew_axis_in_p;
+  cloned_joint->m_square_skew_axis_in_p= this->m_square_skew_axis_in_p;
+  cloned_joint->m_R_pj= this->m_R_pj;
+
+  cloned_joint->m_last_q= this->m_last_q;
+
+  cloned_joint->m_name= this->m_name;
+  cloned_joint->m_parent_link = cloned_parent_link;
+
+  if(m_child_link != 0)
+    cloned_joint->m_child_link = m_child_link->propagateCloning(cloned_joint);
+  else
+    cloned_joint->m_child_link = 0;
+
+  return cloned_joint;
+}
 
 inline void Link::fromUrdf(const urdf::LinkPtr& urdf_link, const rosdyn::JointPtr& parent_joint)
 {
@@ -415,6 +455,27 @@ inline rosdyn::JointPtr Link::findChildJoint(const std::string& name)
   return ptr;
 }
 
+inline rosdyn::LinkPtr& Link::propagateCloning(const rosdyn::JointPtr& cloned_parent_joint)
+{
+  rosdyn::LinkPtr cloned_link = std::make_shared<rosdyn::Link>();
+
+  cloned_link->m_parent_joint = cloned_parent_joint;
+  cloned_link->m_name = this->m_name;
+
+  cloned_link->m_mass = this->m_mass;
+  cloned_link->m_cog_in_c = this->m_cog_in_c;
+  cloned_link->m_Inertia_cc = this->m_Inertia_cc;
+  cloned_link->m_Inertia_cc_single_term = this->m_Inertia_cc_single_term;
+
+  for(const rosdyn::JointPtr& child_joint:m_child_joints)
+  {
+    cloned_link->m_child_joints.push_back(child_joint->propagateCloning(cloned_link));
+    cloned_link->m_child_links.push_back(cloned_link->m_child_joints.back()->getChildLink());
+  }
+
+  return cloned_link;
+}
+
 inline Chain::Chain(const Chain& cpy)
 {
   rosdyn::LinkPtr root_link = cpy.getLinks().front();
@@ -487,6 +548,32 @@ inline Chain& Chain::operator=(const Chain& rhs)
   }
   return *this;
 }
+
+inline rosdyn::ChainPtr& Chain::clone()
+{
+  rosdyn::ChainPtr cloned_chain = std::make_shared<rosdyn::Chain>();
+
+  rosdyn::LinkPtr root_link = this->m_links.front();
+  rosdyn::JointPtr parent_joint = root_link->getParentJoint();
+
+  while(parent_joint != 0)
+  {
+    root_link = parent_joint->getParentLink();
+    parent_joint = root_link->getParentJoint();
+  }
+
+  rosdyn::LinkPtr cloned_root_link = root_link->propagateCloning();
+  std::string base_link_name = this->m_links_name.front();
+  std::string ee_link_name = this->m_links_name.back();
+  Eigen::Vector3d gravity = this->m_gravity;
+
+  std::string error;
+  if(cloned_chain->init(error,cloned_root_link,base_link_name,ee_link_name,gravity))
+    throw std::runtime_error(error.c_str());
+
+  return cloned_chain;
+}
+
 
 //! ADDED TO INIT ALSO STATIC Chain!
 inline bool Chain::init(std::string& error,

--- a/rosdyn_core/include/rosdyn_core/primitives.h
+++ b/rosdyn_core/include/rosdyn_core/primitives.h
@@ -57,6 +57,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace rosdyn
 {
 
+class Joint;
+class Link;
+class Chain;
 
 class Joint: public shared_ptr_namespace::enable_shared_from_this<rosdyn::Joint>
 {
@@ -97,6 +100,7 @@ protected:
 
   void computedTpc();
   void computeJacobian();
+
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   Joint();
@@ -148,6 +152,15 @@ public:
   {
     return (m_type == FIXED);
   }
+
+  /**
+   * @brief propagateCloning return an indipendent copy of the Joint. It starts a cloning cascade,
+   * so that the child Link, its childs joints, and its child links are cloned too.
+   * @param cloned_parent_link is the parent link. It should be a cloned parent link.
+   * @return the cloned Joint. Each member of the object is a cloned version of the original one.
+   */
+  rosdyn::JointPtr& propagateCloning(const rosdyn::LinkPtr& cloned_parent_link = 0);
+
 };
 
 class Link: public shared_ptr_namespace::enable_shared_from_this<rosdyn::Link>
@@ -162,7 +175,6 @@ protected:
   Eigen::Vector3d m_cog_in_c;
   Eigen::Matrix<double, 6, 6> m_Inertia_cc;
   rosdyn::VectorOfMatrix66d m_Inertia_cc_single_term;
-
 
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -210,6 +222,14 @@ public:
   }
 
   Eigen::VectorXd getNominalParameters() const;
+
+  /**
+   * @brief propagateCloning return an indipendent copy of the Link. It starts a cloning cascade,
+   * so that the child Joint, and its child Link are cloned too.
+   * @param cloned_parent_joint is the parent Joint. It should be a cloned parent Joint.
+   * @return the cloned Link. Each member of the object is a cloned version of the original one.
+   */
+  rosdyn::LinkPtr& propagateCloning(const rosdyn::JointPtr& cloned_parent_joint = 0);
 };
 
 class Chain
@@ -527,6 +547,11 @@ public:
   const Eigen::MatrixXd& getJointInertia(const Eigen::VectorXd& q);
   Eigen::VectorXd getNominalParameters();
 
+  /**
+   * @brief clone creates an indipendent clone of the chain, cloning also joints and links usign a cloning cascade
+   * @return the cloned, indipendent chain
+   */
+  rosdyn::ChainPtr& clone();
 };
 
 

--- a/rosdyn_core/include/rosdyn_core/primitives.h
+++ b/rosdyn_core/include/rosdyn_core/primitives.h
@@ -159,7 +159,7 @@ public:
    * @param cloned_parent_link is the parent link. It should be a cloned parent link.
    * @return the cloned Joint. Each member of the object is a cloned version of the original one.
    */
-  rosdyn::JointPtr& propagateCloning(const rosdyn::LinkPtr& cloned_parent_link = 0);
+  rosdyn::JointPtr propagateCloning(const rosdyn::LinkPtr& cloned_parent_link = 0);
 
 };
 
@@ -229,7 +229,7 @@ public:
    * @param cloned_parent_joint is the parent Joint. It should be a cloned parent Joint.
    * @return the cloned Link. Each member of the object is a cloned version of the original one.
    */
-  rosdyn::LinkPtr& propagateCloning(const rosdyn::JointPtr& cloned_parent_joint = 0);
+  rosdyn::LinkPtr propagateCloning(const rosdyn::JointPtr& cloned_parent_joint = 0);
 };
 
 class Chain
@@ -551,7 +551,7 @@ public:
    * @brief clone creates an indipendent clone of the chain, cloning also joints and links usign a cloning cascade
    * @return the cloned, indipendent chain
    */
-  rosdyn::ChainPtr& clone();
+  rosdyn::ChainPtr clone();
 };
 
 


### PR DESCRIPTION
Chain::clone() allows to create an independent copy of the chain. It starts a cloning cascade starting from the root to the end effector. Each link and joint is cloned using propagateCloning(...) function.
Chain::clone() is different from Chain::createChain (Chain cpy) because the latter uses the pointer to the same root link object, so the structure of the robot is shared between the two chains.